### PR TITLE
Set cert location based on where they actually are in the filesystem

### DIFF
--- a/src/include/uc_api.hpp
+++ b/src/include/uc_api.hpp
@@ -50,6 +50,9 @@ struct UCAPITableCredentials {
 
 class UCAPI {
 public:
+  	//! WARNING: not thread-safe. To be called once on extension initialization
+  	static void InitializeCurl();
+
 	static UCAPITableCredentials GetTableCredentials(const string &table_id, UCCredentials credentials);
 	static vector<string> GetCatalogs(const string &catalog, UCCredentials credentials);
 	static vector<UCAPITable> GetTables(const string &catalog, const string &schema, UCCredentials credentials);

--- a/src/uc_api.cpp
+++ b/src/uc_api.cpp
@@ -2,12 +2,43 @@
 #include "storage/uc_catalog.hpp"
 #include "yyjson.hpp"
 #include <curl/curl.h>
+#include <sys/stat.h>
 
 namespace duckdb {
 
 static size_t GetRequestWriteCallback(void *contents, size_t size, size_t nmemb, void *userp) {
 	((std::string *)userp)->append((char *)contents, size * nmemb);
 	return size * nmemb;
+}
+
+// we statically compile in libcurl, which means the cert file location of the build machine is the
+// place curl will look. But not every distro has this file in the same location, so we search a
+// number of common locations and use the first one we find.
+static string certFileLocations[] = {
+        // Arch, Debian-based, Gentoo
+        "/etc/ssl/certs/ca-certificates.crt",
+        // RedHat 7 based
+        "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",
+        // Redhat 6 based
+        "/etc/pki/tls/certs/ca-bundle.crt",
+        // OpenSUSE
+        "/etc/ssl/ca-bundle.pem",
+        // Alpine
+        "/etc/ssl/cert.pem"
+};
+
+// Look through the the above locations and if one of the files exists, set that as the location
+// curl should use. Returns true if a file was set, false if no matching file was found
+static bool SetCurlCAFileInfo(CURL* curl) {
+        for (string& caFile : certFileLocations) {
+                struct stat buf;
+                if (stat(caFile.c_str(), &buf) == 0) {
+                        // file exists
+                        curl_easy_setopt(curl, CURLOPT_CAINFO, caFile.c_str());
+                        return true;
+                }
+        }
+        return false;
 }
 
 static string GetRequest(const string &url, const string &token = "") {
@@ -24,6 +55,7 @@ static string GetRequest(const string &url, const string &token = "") {
 			curl_easy_setopt(curl, CURLOPT_XOAUTH2_BEARER, token.c_str());
 			curl_easy_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_BEARER);
 		}
+                SetCurlCAFileInfo(curl); // todo: log something if this returns false
 		res = curl_easy_perform(curl);
 		curl_easy_cleanup(curl);
 

--- a/src/uc_catalog_extension.cpp
+++ b/src/uc_catalog_extension.cpp
@@ -10,9 +10,10 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/main/extension_util.hpp"
-#include <duckdb/parser/parsed_data/create_scalar_function_info.hpp>
+#include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
 #include "duckdb/parser/parsed_data/attach_info.hpp"
 #include "duckdb/storage/storage_extension.hpp"
+#include "uc_api.hpp"
 
 namespace duckdb {
 
@@ -129,6 +130,8 @@ public:
 };
 
 static void LoadInternal(DatabaseInstance &instance) {
+	UCAPI::InitializeCurl();
+
 	SecretType secret_type;
 	secret_type.name = "uc";
 	secret_type.deserializer = KeyValueSecret::Deserialize<KeyValueSecret>;


### PR DESCRIPTION
This works, but will search the FS on every request.

Looking for guidance on the idiomatic way in a DuckDB extension to store this between calls.