### PR TITLE
Fix TypeToLogicalType Mappings to Support CHAR, CHAR(N), VARCHAR(N), VOID and fix TIMESTAMP type.

### DIFF
--- a/src/uc_utils.cpp
+++ b/src/uc_utils.cpp
@@ -39,9 +39,7 @@ LogicalType UCUtils::TypeToLogicalType(ClientContext &context, const string &typ
 		return LogicalType::INTEGER;
 	} else if (type_text == "long") {
 		return LogicalType::BIGINT;
-	} else if (type_text == "char" || type_text.find("char(") == 0) {
-		return LogicalType::CHAR;
-	} else if (type_text == "string" || type_text.find("varchar(") == 0) {
+	} else if (type_text == "string" || type_text.find("varchar(") == 0|| type_text == "char"  || type_text.find("char(") == 0) {
 		return LogicalType::VARCHAR;
 	} else if (type_text == "double") {
 		return LogicalType::DOUBLE;

--- a/src/uc_utils.cpp
+++ b/src/uc_utils.cpp
@@ -39,7 +39,7 @@ LogicalType UCUtils::TypeToLogicalType(ClientContext &context, const string &typ
 		return LogicalType::INTEGER;
 	} else if (type_text == "long") {
 		return LogicalType::BIGINT;
-	} else if (type_text == "string") {
+	} else if (type_text == "string" || type_text.find("varchar(") == 0) {
 		return LogicalType::VARCHAR;
 	} else if (type_text == "double") {
 		return LogicalType::DOUBLE;
@@ -48,13 +48,13 @@ LogicalType UCUtils::TypeToLogicalType(ClientContext &context, const string &typ
 	} else if (type_text == "boolean") {
 		return LogicalType::BOOLEAN;
 	} else if (type_text == "timestamp") {
-		return LogicalType::TIMESTAMP;
+		return LogicalType::TIMESTAMP_TZ;
 	} else if (type_text == "binary") {
 		return LogicalType::BLOB;
 	} else if (type_text == "date") {
 		return LogicalType::DATE;
-	} else if (type_text == "timestamp") {
-		return LogicalType::TIMESTAMP; // TODO: Is this the right timestamp
+	} else if (type_text == "void") {
+		return LogicalType::SQLNULL; // TODO: This seems to be the closest match
 	} else if (type_text.find("decimal(") == 0) {
 		size_t spec_end = type_text.find(')');
 		if (spec_end != string::npos) {

--- a/src/uc_utils.cpp
+++ b/src/uc_utils.cpp
@@ -39,7 +39,10 @@ LogicalType UCUtils::TypeToLogicalType(ClientContext &context, const string &typ
 		return LogicalType::INTEGER;
 	} else if (type_text == "long") {
 		return LogicalType::BIGINT;
-	} else if (type_text == "string" || type_text.find("varchar(") == 0|| type_text == "char"  || type_text.find("char(") == 0) {
+	} else if (type_text == "string" ||
+	           type_text.find("varchar(") == 0 ||
+	           type_text == "char" ||
+	           type_text.find("char(") == 0) {
 		return LogicalType::VARCHAR;
 	} else if (type_text == "double") {
 		return LogicalType::DOUBLE;

--- a/src/uc_utils.cpp
+++ b/src/uc_utils.cpp
@@ -39,6 +39,8 @@ LogicalType UCUtils::TypeToLogicalType(ClientContext &context, const string &typ
 		return LogicalType::INTEGER;
 	} else if (type_text == "long") {
 		return LogicalType::BIGINT;
+	} else if (type_text == "char" || type_text.find("char(") == 0) {
+		return LogicalType::CHAR;
 	} else if (type_text == "string" || type_text.find("varchar(") == 0) {
 		return LogicalType::VARCHAR;
 	} else if (type_text == "double") {


### PR DESCRIPTION
Delta tables with types CHAR, CHAR(N), VARCHAR(N) or VOID previously failed with:
```
NotImplementedException("Tried to fallback to unknown type for '%s'", type_text);
```
This PR maps them to the correct LogicalType.

Additionally, the TIMESTAMP datatype in Delta has a timezone component, so switching it to use TIMESTAMP_TZ solves an error which manifests as:
```
vector::Reference used on vector of different type
```

This all built and tested successfully on my fork: https://github.com/alarocca-apixio/uc_catalog/actions/runs/13033816457